### PR TITLE
Add `readonly` attribute to textareas

### DIFF
--- a/pubkeys.html
+++ b/pubkeys.html
@@ -6,7 +6,7 @@
 <p>Last Updated: 2022-04-29, also available as <a href="/installer.sig">https://composer.github.io/installer.sig</a> (checksum only) or <a href="/installer.sha384sum">https://composer.github.io/installer.sha384sum</a> (sha384sum compatible) for scripting purposes.</p>
 
 <h2>Dev / Snapshot Public Key</h2>
-<textarea rows="16" cols="70">
+<textarea rows="16" cols="70" readonly>
 -----BEGIN PUBLIC KEY-----
 MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAnBDHjZS6e0ZMoK3xTD7f
 FNCzlXjX/Aie2dit8QXA03pSrOTbaMnxON3hUL47Lz3g1SC6YJEMVHr0zYq4elWi
@@ -28,7 +28,7 @@ Fingerprint: <code style="white-space:pre">4AC45767 E5EC2265 2F0C1167 CBBB8A2B  
 Also available as <a href="/snapshots.pub">https://composer.github.io/snapshots.pub</a></p>
 
 <h2>Tags Public Key</h2>
-<textarea rows="16" cols="70">
+<textarea rows="16" cols="70" readonly>
 -----BEGIN PUBLIC KEY-----
 MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA0Vi/2K6apCVj76nCnCl2
 MQUPdK+A9eqkYBacXo2wQBYmyVlXm2/n/ZsX6pCLYPQTHyr5jXbkQzBw8SKqPdlh


### PR DESCRIPTION
Textareas with keys are now editable, so accidental keystrokes can corrupt the text.